### PR TITLE
Fix pattern check on release label

### DIFF
--- a/src/components/Milestone.vue
+++ b/src/components/Milestone.vue
@@ -61,7 +61,7 @@
               type="text"
               required
               minlength="10"
-              pattern="^Release [0-9.A-Z]{3,7}$"
+              pattern="^Release [0-9.A-Z]{3,}$"
               placeholder="Current milestone title"
               list="possibleReleaseNames">
             <datalist id="possibleReleaseNames">


### PR DESCRIPTION
It can't proceed after more than 7 characters .eg Release 3.108.10